### PR TITLE
カード情報入力欄非表示機能削除

### DIFF
--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -35,7 +35,6 @@
     <%= form_with model: @purchase_address, url: item_purchases_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
     
-    <% unless @card.present? %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -75,8 +74,6 @@
       </div>
     </div>
     <%# /カード情報の入力 %>
-    
-    <% else %>
     
     <%# 配送先の入力 %>
     <div class='shipping-address-form'>
@@ -130,7 +127,6 @@
     <div class='buy-btn'>
       <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
     </div>
-    <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
カード情報欄を非表示にすると購入ボタンが押せなくさる不具合が発生。
原因は未特定だが、JavaScriptのカード情報取得のプログラムが関わっていると予想